### PR TITLE
Add instruction SEV

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -23,6 +23,7 @@ pub fn nop() {
 }
 
 /// Wait For Event
+///
 /// For more details of wfe - sev pair, refer to [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0802a/CIHEGBBF.html)
 #[inline(always)]
 pub fn wfe() {
@@ -35,8 +36,10 @@ pub fn wfe() {
     }
 }
 
-/// Send an event.
+/// Send EVent.
+///
 /// SEV causes an event to be signaled to all cores within a multiprocessor system.
+///
 /// For more details of wfe - sev pair, refer to [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0802a/CIHEGBBF.html)
 #[inline(always)]
 pub fn sev() {

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -23,11 +23,26 @@ pub fn nop() {
 }
 
 /// Wait For Event
+/// For more details of wfe - sev pair, refer to [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0802a/CIHEGBBF.html)
 #[inline(always)]
 pub fn wfe() {
     match () {
         #[cfg(target_arch = "aarch64")]
         () => unsafe { asm!("wfe" :::: "volatile") },
+
+        #[cfg(not(target_arch = "aarch64"))]
+        () => unimplemented!(),
+    }
+}
+
+/// Send an event.
+/// SEV causes an event to be signaled to all cores within a multiprocessor system.
+/// For more details of wfe - sev pair, refer to [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0802a/CIHEGBBF.html)
+#[inline(always)]
+pub fn sev() {
+    match () {
+        #[cfg(target_arch = "aarch64")]
+        () => unsafe { asm!("sev" :::: "volatile") },
 
         #[cfg(not(target_arch = "aarch64"))]
         () => unimplemented!(),


### PR DESCRIPTION
Since this crate already provides WFE, according to [ARM documentation](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0802a/CIHEGBBF.html) instruction WFE and SEV should be paired to wake up other cores.

P.S. I've trying to write an OS project using rust and used your crate a lot. It provided much help. Thanks.