### PR TITLE
Allow reusing register macros

### DIFF
--- a/src/regs/mod.rs
+++ b/src/regs/mod.rs
@@ -3,7 +3,7 @@
 #![rustfmt::skip]
 
 #[macro_use]
-mod macros;
+pub mod macros;
 
 mod cntfrq_el0;
 mod cnthctl_el2;


### PR DESCRIPTION
For those who implement register definitions themselves, it's a pain to have
to copypaste these macros.

Make them reusable.