### PR TITLE
Support ASID bits in ID_AA64MMFR0_EL1

### DIFF
--- a/src/regs/id_aa64mmfr0_el1.rs
+++ b/src/regs/id_aa64mmfr0_el1.rs
@@ -47,6 +47,17 @@ register_bitfields! {u64,
             NotSupported = 0b0000
         ],
 
+        /// Number of bits supported in the ASID:
+        ///
+        /// 0000 ASIDs are 8 bits.
+        /// 0010 ASIDs are 16 bits.
+        ///
+        /// All other values are reserved.
+        ASIDBits OFFSET(4) NUMBITS(4) [
+            Bits_8 = 0b0000,
+            Bits_16 = 0b0010
+        ],
+
         /// Physical Address range supported. Defined values are:
         ///
         /// 0000 32 bits, 4GiB.


### PR DESCRIPTION
Used in my queries, I could drop custom implementation of ID_AA64MMFR0_EL1 once this is merged.