### PR TITLE
Feature/asm syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Low level access to Cortex-A processors.
 - [x] AArch64
 - [ ] AArch32
 
+## Minimum Supported Rust Version
+
+Requires rustc 1.45.0 or later due to use of the new `asm!()` syntax.
+
 ## Usage
 
 Example from https://github.com/rust-embedded/rust-raspi3-OS-tutorials

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -13,7 +13,7 @@
 pub fn nop() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        llvm_asm!("nop" :::: "volatile")
+        asm!("nop", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -27,7 +27,7 @@ pub fn nop() {
 pub fn wfi() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        llvm_asm!("wfi" :::: "volatile")
+        asm!("wfi", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -41,7 +41,7 @@ pub fn wfi() {
 pub fn wfe() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        llvm_asm!("wfe" :::: "volatile")
+        asm!("wfe", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -57,7 +57,7 @@ pub fn wfe() {
 pub fn sevl() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        llvm_asm!("sevl" :::: "volatile")
+        asm!("sevl", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -73,7 +73,7 @@ pub fn sevl() {
 pub fn sev() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        llvm_asm!("sev" :::: "volatile")
+        asm!("sev", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -87,7 +87,7 @@ pub fn sev() {
 pub fn eret() -> ! {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        llvm_asm!("eret" :::: "volatile");
+        asm!("eret", options(nomem, nostack));
         core::intrinsics::unreachable()
     }
 
@@ -102,7 +102,7 @@ pub fn eret() -> ! {
 pub fn ret() -> ! {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        llvm_asm!("ret" :::: "volatile");
+        asm!("ret", options(nomem, nostack));
         core::intrinsics::unreachable()
     }
 

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -29,13 +29,13 @@ macro_rules! dmb_dsb {
         impl sealed::Dmb for $A {
             #[inline(always)]
             unsafe fn __dmb(&self) {
-                llvm_asm!(concat!("DMB ", stringify!($A)) : : : "memory" : "volatile")
+                asm!(concat!("DMB ", stringify!($A)), options(nostack))
             }
         }
         impl sealed::Dsb for $A {
             #[inline(always)]
             unsafe fn __dsb(&self) {
-                llvm_asm!(concat!("DSB ", stringify!($A)) : : : "memory" : "volatile")
+                asm!(concat!("DSB ", stringify!($A)), options(nostack))
             }
         }
     };
@@ -52,7 +52,7 @@ dmb_dsb!(SY);
 impl sealed::Isb for SY {
     #[inline(always)]
     unsafe fn __isb(&self) {
-        llvm_asm!("ISB SY" : : : "memory" : "volatile")
+        asm!("ISB SY", options(nostack))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 #![feature(core_intrinsics)]
 #![feature(custom_inner_attributes)]
 #![feature(asm)]
-#![feature(llvm_asm)]
 #![no_std]
 
 pub mod asm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 
 #![feature(core_intrinsics)]
 #![feature(custom_inner_attributes)]
+#![feature(asm)]
 #![feature(llvm_asm)]
 #![no_std]
 

--- a/src/regs/cntfrq_el0.rs
+++ b/src/regs/cntfrq_el0.rs
@@ -16,7 +16,7 @@ use register::cpu::RegisterReadOnly;
 pub struct Reg;
 
 impl RegisterReadOnly<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "CNTFRQ_EL0");
+    sys_coproc_read_raw!(u64, "CNTFRQ_EL0", "x");
 }
 
 pub static CNTFRQ_EL0: Reg = Reg {};

--- a/src/regs/cnthctl_el2.rs
+++ b/src/regs/cnthctl_el2.rs
@@ -54,8 +54,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, CNTHCTL_EL2::Register> for Reg {
-    sys_coproc_read_raw!(u64, "CNTHCTL_EL2");
-    sys_coproc_write_raw!(u64, "CNTHCTL_EL2");
+    sys_coproc_read_raw!(u64, "CNTHCTL_EL2", "x");
+    sys_coproc_write_raw!(u64, "CNTHCTL_EL2", "x");
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/regs/cntp_ctl_el0.rs
+++ b/src/regs/cntp_ctl_el0.rs
@@ -44,8 +44,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, CNTP_CTL_EL0::Register> for Reg {
-    sys_coproc_read_raw!(u64, "CNTP_CTL_EL0");
-    sys_coproc_write_raw!(u64, "CNTP_CTL_EL0");
+    sys_coproc_read_raw!(u64, "CNTP_CTL_EL0", "x");
+    sys_coproc_write_raw!(u64, "CNTP_CTL_EL0", "x");
 }
 
 pub static CNTP_CTL_EL0: Reg = Reg {};

--- a/src/regs/cntp_tval_el0.rs
+++ b/src/regs/cntp_tval_el0.rs
@@ -14,8 +14,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "CNTP_TVAL_EL0");
-    sys_coproc_write_raw!(u64, "CNTP_TVAL_EL0");
+    sys_coproc_read_raw!(u64, "CNTP_TVAL_EL0", "x");
+    sys_coproc_write_raw!(u64, "CNTP_TVAL_EL0", "x");
 }
 
 pub static CNTP_TVAL_EL0: Reg = Reg {};

--- a/src/regs/cntpct_el0.rs
+++ b/src/regs/cntpct_el0.rs
@@ -14,7 +14,7 @@ use register::cpu::RegisterReadOnly;
 pub struct Reg;
 
 impl RegisterReadOnly<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "CNTPCT_EL0");
+    sys_coproc_read_raw!(u64, "CNTPCT_EL0", "x");
 }
 
 pub static CNTPCT_EL0: Reg = Reg {};

--- a/src/regs/cntv_ctl_el0.rs
+++ b/src/regs/cntv_ctl_el0.rs
@@ -50,8 +50,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, CNTV_CTL_EL0::Register> for Reg {
-    sys_coproc_read_raw!(u64, "CNTV_CTL_EL0");
-    sys_coproc_write_raw!(u64, "CNTV_CTL_EL0");
+    sys_coproc_read_raw!(u64, "CNTV_CTL_EL0", "x");
+    sys_coproc_write_raw!(u64, "CNTV_CTL_EL0", "x");
 }
 
 pub static CNTV_CTL_EL0: Reg = Reg {};

--- a/src/regs/cntv_tval_el0.rs
+++ b/src/regs/cntv_tval_el0.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "CNTV_TVAL_EL0");
-    sys_coproc_write_raw!(u64, "CNTV_TVAL_EL0");
+    sys_coproc_read_raw!(u64, "CNTV_TVAL_EL0", "x");
+    sys_coproc_write_raw!(u64, "CNTV_TVAL_EL0", "x");
 }
 
 pub static CNTV_TVAL_EL0: Reg = Reg {};

--- a/src/regs/cntvct_el0.rs
+++ b/src/regs/cntvct_el0.rs
@@ -16,7 +16,7 @@ use register::cpu::RegisterReadOnly;
 pub struct Reg;
 
 impl RegisterReadOnly<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "CNTVCT_EL0");
+    sys_coproc_read_raw!(u64, "CNTVCT_EL0", "x");
 }
 
 pub static CNTVCT_EL0: Reg = Reg {};

--- a/src/regs/cntvoff_el2.rs
+++ b/src/regs/cntvoff_el2.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "CNTVOFF_EL2");
-    sys_coproc_write_raw!(u64, "CNTVOFF_EL2");
+    sys_coproc_read_raw!(u64, "CNTVOFF_EL2", "x");
+    sys_coproc_write_raw!(u64, "CNTVOFF_EL2", "x");
 }
 
 pub static CNTVOFF_EL2: Reg = Reg {};

--- a/src/regs/currentel.rs
+++ b/src/regs/currentel.rs
@@ -36,7 +36,7 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadOnly<u64, CurrentEL::Register> for Reg {
-    sys_coproc_read_raw!(u64, "CurrentEL");
+    sys_coproc_read_raw!(u64, "CurrentEL", "x");
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/regs/daif.rs
+++ b/src/regs/daif.rs
@@ -68,8 +68,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, DAIF::Register> for Reg {
-    sys_coproc_read_raw!(u64, "DAIF");
-    sys_coproc_write_raw!(u64, "DAIF");
+    sys_coproc_read_raw!(u64, "DAIF", "x");
+    sys_coproc_write_raw!(u64, "DAIF", "x");
 }
 
 pub static DAIF: Reg = Reg {};

--- a/src/regs/elr_el1.rs
+++ b/src/regs/elr_el1.rs
@@ -14,8 +14,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "ELR_EL1");
-    sys_coproc_write_raw!(u64, "ELR_EL1");
+    sys_coproc_read_raw!(u64, "ELR_EL1", "x");
+    sys_coproc_write_raw!(u64, "ELR_EL1", "x");
 }
 
 pub static ELR_EL1: Reg = Reg {};

--- a/src/regs/elr_el2.rs
+++ b/src/regs/elr_el2.rs
@@ -14,8 +14,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "ELR_EL2");
-    sys_coproc_write_raw!(u64, "ELR_EL2");
+    sys_coproc_read_raw!(u64, "ELR_EL2", "x");
+    sys_coproc_write_raw!(u64, "ELR_EL2", "x");
 }
 
 pub static ELR_EL2: Reg = Reg {};

--- a/src/regs/elr_el3.rs
+++ b/src/regs/elr_el3.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "ELR_EL3");
-    sys_coproc_write_raw!(u64, "ELR_EL3");
+    sys_coproc_read_raw!(u64, "ELR_EL3", "x");
+    sys_coproc_write_raw!(u64, "ELR_EL3", "x");
 }
 
 pub static ELR_EL3: Reg = Reg {};

--- a/src/regs/esr_el1.rs
+++ b/src/regs/esr_el1.rs
@@ -73,7 +73,7 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadOnly<u64, ESR_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "ESR_EL1");
+    sys_coproc_read_raw!(u64, "ESR_EL1", "x");
 }
 
 pub static ESR_EL1: Reg = Reg {};

--- a/src/regs/far_el1.rs
+++ b/src/regs/far_el1.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "FAR_EL1");
-    sys_coproc_write_raw!(u64, "FAR_EL1");
+    sys_coproc_read_raw!(u64, "FAR_EL1", "x");
+    sys_coproc_write_raw!(u64, "FAR_EL1", "x");
 }
 
 pub static FAR_EL1: Reg = Reg {};

--- a/src/regs/far_el2.rs
+++ b/src/regs/far_el2.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "FAR_EL2");
-    sys_coproc_write_raw!(u64, "FAR_EL2");
+    sys_coproc_read_raw!(u64, "FAR_EL2", "x");
+    sys_coproc_write_raw!(u64, "FAR_EL2", "x");
 }
 
 pub static FAR_EL2: Reg = Reg {};

--- a/src/regs/hcr_el2.rs
+++ b/src/regs/hcr_el2.rs
@@ -96,8 +96,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, HCR_EL2::Register> for Reg {
-    sys_coproc_read_raw!(u64, "HCR_EL2");
-    sys_coproc_write_raw!(u64, "HCR_EL2");
+    sys_coproc_read_raw!(u64, "HCR_EL2", "x");
+    sys_coproc_write_raw!(u64, "HCR_EL2", "x");
 }
 
 pub static HCR_EL2: Reg = Reg {};

--- a/src/regs/id_aa64mmfr0_el1.rs
+++ b/src/regs/id_aa64mmfr0_el1.rs
@@ -87,7 +87,7 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadOnly<u64, ID_AA64MMFR0_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "ID_AA64MMFR0_EL1");
+    sys_coproc_read_raw!(u64, "ID_AA64MMFR0_EL1", "x");
 }
 
 pub static ID_AA64MMFR0_EL1: Reg = Reg {};

--- a/src/regs/lr.rs
+++ b/src/regs/lr.rs
@@ -13,8 +13,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    read_raw!(u64, "lr");
-    write_raw!(u64, "lr");
+    read_raw!(u64, "lr", "x");
+    write_raw!(u64, "lr", "x");
 }
 
 pub static LR: Reg = Reg {};

--- a/src/regs/macros.rs
+++ b/src/regs/macros.rs
@@ -6,7 +6,7 @@
 //   - Andre Richter <andre.o.richter@gmail.com>
 
 macro_rules! __read_raw {
-    ($width:ty, $asm_instr:tt, $asm_reg_name:tt) => {
+    ($width:ty, $asm_instr:tt, $asm_reg_name:tt, $asm_width:tt) => {
         /// Reads the raw bits of the CPU register.
         #[inline]
         fn get(&self) -> $width {
@@ -15,7 +15,7 @@ macro_rules! __read_raw {
                 () => {
                     let reg;
                     unsafe {
-                        llvm_asm!(concat!($asm_instr, " $0, ", $asm_reg_name) : "=r"(reg) ::: "volatile");
+                        asm!(concat!($asm_instr, " {reg:", $asm_width, "}, ", $asm_reg_name), reg = out(reg) reg, options(nomem, nostack));
                     }
                     reg
                 }
@@ -28,7 +28,7 @@ macro_rules! __read_raw {
 }
 
 macro_rules! __write_raw {
-    ($width:ty, $asm_instr:tt, $asm_reg_name:tt) => {
+    ($width:ty, $asm_instr:tt, $asm_reg_name:tt, $asm_width:tt) => {
         /// Writes raw bits to the CPU register.
         #[cfg_attr(not(target_arch = "aarch64"), allow(unused_variables))]
         #[inline]
@@ -37,7 +37,7 @@ macro_rules! __write_raw {
                 #[cfg(target_arch = "aarch64")]
                 () => {
                     unsafe {
-                        llvm_asm!(concat!($asm_instr, " ", $asm_reg_name, ", $0") :: "r"(value) :: "volatile")
+                        asm!(concat!($asm_instr, " ", $asm_reg_name, ", {reg:", $asm_width, "}"), reg = in(reg) value, options(nomem, nostack))
                     }
                 }
 
@@ -50,27 +50,27 @@ macro_rules! __write_raw {
 
 /// Raw read from system coprocessor registers.
 macro_rules! sys_coproc_read_raw {
-    ($width:ty, $asm_reg_name:tt) => {
-        __read_raw!($width, "mrs", $asm_reg_name);
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __read_raw!($width, "mrs", $asm_reg_name, $asm_width);
     };
 }
 
 /// Raw write to system coprocessor registers.
 macro_rules! sys_coproc_write_raw {
-    ($width:ty, $asm_reg_name:tt) => {
-        __write_raw!($width, "msr", $asm_reg_name);
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __write_raw!($width, "msr", $asm_reg_name, $asm_width);
     };
 }
 
 /// Raw read from (ordinary) registers.
 macro_rules! read_raw {
-    ($width:ty, $asm_reg_name:tt) => {
-        __read_raw!($width, "mov", $asm_reg_name);
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __read_raw!($width, "mov", $asm_reg_name, $asm_width);
     };
 }
 /// Raw write to (ordinary) registers.
 macro_rules! write_raw {
-    ($width:ty, $asm_reg_name:tt) => {
-        __write_raw!($width, "mov", $asm_reg_name);
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __write_raw!($width, "mov", $asm_reg_name, $asm_width);
     };
 }

--- a/src/regs/mair_el1.rs
+++ b/src/regs/mair_el1.rs
@@ -428,8 +428,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, MAIR_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "MAIR_EL1");
-    sys_coproc_write_raw!(u64, "MAIR_EL1");
+    sys_coproc_read_raw!(u64, "MAIR_EL1", "x");
+    sys_coproc_write_raw!(u64, "MAIR_EL1", "x");
 }
 
 pub static MAIR_EL1: Reg = Reg {};

--- a/src/regs/midr_el1.rs
+++ b/src/regs/midr_el1.rs
@@ -87,7 +87,7 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadOnly<u64, MIDR_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "MIDR_EL1");
+    sys_coproc_read_raw!(u64, "MIDR_EL1", "x");
 }
 
 pub static MIDR_EL1: Reg = Reg {};

--- a/src/regs/mpidr_el1.rs
+++ b/src/regs/mpidr_el1.rs
@@ -15,7 +15,7 @@ use register::cpu::RegisterReadOnly;
 pub struct Reg;
 
 impl RegisterReadOnly<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "MPIDR_EL1");
+    sys_coproc_read_raw!(u64, "MPIDR_EL1", "x");
 }
 
 pub static MPIDR_EL1: Reg = Reg {};

--- a/src/regs/scr_el3.rs
+++ b/src/regs/scr_el3.rs
@@ -54,8 +54,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, SCR_EL3::Register> for Reg {
-    sys_coproc_read_raw!(u64, "SCR_EL3");
-    sys_coproc_write_raw!(u64, "SCR_EL3");
+    sys_coproc_read_raw!(u64, "SCR_EL3", "x");
+    sys_coproc_write_raw!(u64, "SCR_EL3", "x");
 }
 
 pub static SCR_EL3: Reg = Reg {};

--- a/src/regs/sctlr_el1.rs
+++ b/src/regs/sctlr_el1.rs
@@ -80,8 +80,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, SCTLR_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "SCTLR_EL1");
-    sys_coproc_write_raw!(u64, "SCTLR_EL1");
+    sys_coproc_read_raw!(u64, "SCTLR_EL1", "x");
+    sys_coproc_write_raw!(u64, "SCTLR_EL1", "x");
 }
 
 pub static SCTLR_EL1: Reg = Reg {};

--- a/src/regs/sp.rs
+++ b/src/regs/sp.rs
@@ -12,8 +12,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    read_raw!(u64, "sp");
-    write_raw!(u64, "sp");
+    read_raw!(u64, "sp", "x");
+    write_raw!(u64, "sp", "x");
 }
 
 pub static SP: Reg = Reg {};

--- a/src/regs/sp_el0.rs
+++ b/src/regs/sp_el0.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "SP_EL0");
-    sys_coproc_write_raw!(u64, "SP_EL0");
+    sys_coproc_read_raw!(u64, "SP_EL0", "x");
+    sys_coproc_write_raw!(u64, "SP_EL0", "x");
 }
 
 pub static SP_EL0: Reg = Reg {};

--- a/src/regs/sp_el1.rs
+++ b/src/regs/sp_el1.rs
@@ -20,8 +20,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "SP_EL1");
-    sys_coproc_write_raw!(u64, "SP_EL1");
+    sys_coproc_read_raw!(u64, "SP_EL1", "x");
+    sys_coproc_write_raw!(u64, "SP_EL1", "x");
 }
 
 pub static SP_EL1: Reg = Reg {};

--- a/src/regs/spsel.rs
+++ b/src/regs/spsel.rs
@@ -29,8 +29,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, SPSel::Register> for Reg {
-    sys_coproc_read_raw!(u64, "SPSEL");
-    sys_coproc_write_raw!(u64, "SPSEL");
+    sys_coproc_read_raw!(u64, "SPSEL", "x");
+    sys_coproc_write_raw!(u64, "SPSEL", "x");
 }
 
 #[allow(non_upper_case_globals)]

--- a/src/regs/spsr_el1.rs
+++ b/src/regs/spsr_el1.rs
@@ -126,8 +126,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, SPSR_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "SPSR_EL1");
-    sys_coproc_write_raw!(u64, "SPSR_EL1");
+    sys_coproc_read_raw!(u64, "SPSR_EL1", "x");
+    sys_coproc_write_raw!(u64, "SPSR_EL1", "x");
 }
 
 pub static SPSR_EL1: Reg = Reg {};

--- a/src/regs/spsr_el2.rs
+++ b/src/regs/spsr_el2.rs
@@ -130,8 +130,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, SPSR_EL2::Register> for Reg {
-    sys_coproc_read_raw!(u64, "SPSR_EL2");
-    sys_coproc_write_raw!(u64, "SPSR_EL2");
+    sys_coproc_read_raw!(u64, "SPSR_EL2", "x");
+    sys_coproc_write_raw!(u64, "SPSR_EL2", "x");
 }
 
 pub static SPSR_EL2: Reg = Reg {};

--- a/src/regs/spsr_el3.rs
+++ b/src/regs/spsr_el3.rs
@@ -131,8 +131,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, SPSR_EL3::Register> for Reg {
-    sys_coproc_read_raw!(u64, "SPSR_EL3");
-    sys_coproc_write_raw!(u64, "SPSR_EL3");
+    sys_coproc_read_raw!(u64, "SPSR_EL3", "x");
+    sys_coproc_write_raw!(u64, "SPSR_EL3", "x");
 }
 
 pub static SPSR_EL3: Reg = Reg {};

--- a/src/regs/tcr_el1.rs
+++ b/src/regs/tcr_el1.rs
@@ -322,8 +322,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, TCR_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "TCR_EL1");
-    sys_coproc_write_raw!(u64, "TCR_EL1");
+    sys_coproc_read_raw!(u64, "TCR_EL1", "x");
+    sys_coproc_write_raw!(u64, "TCR_EL1", "x");
 }
 
 pub static TCR_EL1: Reg = Reg {};

--- a/src/regs/tpidr_el0.rs
+++ b/src/regs/tpidr_el0.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "TPIDR_EL0");
-    sys_coproc_write_raw!(u64, "TPIDR_EL0");
+    sys_coproc_read_raw!(u64, "TPIDR_EL0", "x");
+    sys_coproc_write_raw!(u64, "TPIDR_EL0", "x");
 }
 
 pub static TPIDR_EL0: Reg = Reg {};

--- a/src/regs/tpidr_el1.rs
+++ b/src/regs/tpidr_el1.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "TPIDR_EL1");
-    sys_coproc_write_raw!(u64, "TPIDR_EL1");
+    sys_coproc_read_raw!(u64, "TPIDR_EL1", "x");
+    sys_coproc_write_raw!(u64, "TPIDR_EL1", "x");
 }
 
 pub static TPIDR_EL1: Reg = Reg {};

--- a/src/regs/tpidrro_el0.rs
+++ b/src/regs/tpidrro_el0.rs
@@ -15,8 +15,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "TPIDRRO_EL0");
-    sys_coproc_write_raw!(u64, "TPIDRRO_EL0");
+    sys_coproc_read_raw!(u64, "TPIDRRO_EL0", "x");
+    sys_coproc_write_raw!(u64, "TPIDRRO_EL0", "x");
 }
 
 pub static TPIDRRO_EL0: Reg = Reg {};

--- a/src/regs/ttbr0_el1.rs
+++ b/src/regs/ttbr0_el1.rs
@@ -33,8 +33,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, TTBR0_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "TTBR0_EL1");
-    sys_coproc_write_raw!(u64, "TTBR0_EL1");
+    sys_coproc_read_raw!(u64, "TTBR0_EL1", "x");
+    sys_coproc_write_raw!(u64, "TTBR0_EL1", "x");
 }
 
 impl Reg {

--- a/src/regs/ttbr1_el1.rs
+++ b/src/regs/ttbr1_el1.rs
@@ -33,8 +33,8 @@ register_bitfields! {u64,
 pub struct Reg;
 
 impl RegisterReadWrite<u64, TTBR1_EL1::Register> for Reg {
-    sys_coproc_read_raw!(u64, "TTBR1_EL1");
-    sys_coproc_write_raw!(u64, "TTBR1_EL1");
+    sys_coproc_read_raw!(u64, "TTBR1_EL1", "x");
+    sys_coproc_write_raw!(u64, "TTBR1_EL1", "x");
 }
 
 impl Reg {

--- a/src/regs/vbar_el1.rs
+++ b/src/regs/vbar_el1.rs
@@ -14,8 +14,8 @@ use register::cpu::RegisterReadWrite;
 pub struct Reg;
 
 impl RegisterReadWrite<u64, ()> for Reg {
-    sys_coproc_read_raw!(u64, "VBAR_EL1");
-    sys_coproc_write_raw!(u64, "VBAR_EL1");
+    sys_coproc_read_raw!(u64, "VBAR_EL1", "x");
+    sys_coproc_write_raw!(u64, "VBAR_EL1", "x");
 }
 
 pub static VBAR_EL1: Reg = Reg {};


### PR DESCRIPTION
Switch from llvm_asm!() syntax to asm!() syntax.

Add register width specification for future expansion.

Since asm!() is not fully stabilised this might need to wait, but I still want to push it out from my PR closet.