### PR TITLE
correct 64kbits granules

### DIFF
--- a/src/regs/tcr_el1.rs
+++ b/src/regs/tcr_el1.rs
@@ -132,9 +132,9 @@ register_bitfields! {u64,
 
         /// Granule size for the TTBR1_EL1.
         ///
-        /// 00 4KiB
-        /// 01 64KiB
-        /// 10 16KiB
+        /// 10 4KiB
+        /// 01 16KiB
+        /// 11 64KiB
         ///
         /// Other values are reserved.
         ///
@@ -146,9 +146,9 @@ register_bitfields! {u64,
         /// It is IMPLEMENTATION DEFINED whether the value read back is the value programmed or the
         /// value that corresponds to the size chosen.
         TG1   OFFSET(30) NUMBITS(2) [
-            KiB_4 = 0b00,
-            KiB_16 = 0b10,
-            KiB_64 = 0b01
+            KiB_4 = 0b10,
+            KiB_16 = 0b01,
+            KiB_64 = 0b11
         ],
 
         /// Shareability attribute for memory associated with translation table walks using


### PR DESCRIPTION
There is an issue on the TG0 and TG1 field on TCR_EL1 register. 
For some reason, it works when using TG0 (qemu/arm apparently correct the issue silently) but it does not work with TG1. 

According to armv8_a_address_translation : 

The Intermediate Physical Address Size (IPS) field controls the maximum output address size. If translations specify output addresses outside this range, then access is faulted, 000=32 bits of physical address, 101=48 bits. The two-bit Translation Granule (TG) TG1 and TG0 fields give the granule size for kernel or user space respectively, **00=4KB, 01=16KB, 11=64KB**. The size of the Translation Granule indicates the smallest block of memory that can be independently mapped in the translation tables.