### PR TITLE
Make SPSR_EL3 and SCR_EL3 bitfields accessible

### DIFF
--- a/src/regs/scr_el3.rs
+++ b/src/regs/scr_el3.rs
@@ -37,6 +37,24 @@ register_bitfields! {u64,
             AllLowerELsAreAarch32 = 0,
             NextELIsAarch64 = 1
         ],
+        /// Hypervisor Call Enable
+        ///
+        /// 0 The HVC instruction is undefined at all exception levels.
+        /// 1 The HVC instruction is enabled at EL1, EL2, or EL3
+        HCE OFFSET(8) NUMBITS(1) [
+            HvcDisabled = 0,
+            HvcEnabled = 1
+        ],
+
+        /// Secure Monitor call Disable
+        ///
+        /// 0 The SMC instruction is enabled at EL1, EL2, and EL3.
+        /// 1 The SMC instruction is undefined at all exception levels. At EL1, in the Non-secure
+        /// state, the HCR_EL2.TSC bit has priority over this control.
+        SMD OFFSET(7) NUMBITS(1) [
+            SmcEnabled = 0,
+            SmcDisabled = 1
+        ],
 
         /// Non-secure bit.
         /// * 0b0 Indicates that EL0 and EL1 are in Secure state.

--- a/src/regs/scr_el3.rs
+++ b/src/regs/scr_el3.rs
@@ -37,6 +37,7 @@ register_bitfields! {u64,
             AllLowerELsAreAarch32 = 0,
             NextELIsAarch64 = 1
         ],
+
         /// Hypervisor Call Enable
         ///
         /// 0 The HVC instruction is undefined at all exception levels.

--- a/src/regs/scr_el3.rs
+++ b/src/regs/scr_el3.rs
@@ -14,7 +14,7 @@
 use register::{cpu::RegisterReadWrite, register_bitfields};
 
 register_bitfields! {u64,
-    SCR_EL3 [
+    pub SCR_EL3 [
         /// Execution state control for lower Exception levels:
         ///
         /// 0 Lower levels are all AArch32.

--- a/src/regs/spsr_el3.rs
+++ b/src/regs/spsr_el3.rs
@@ -13,7 +13,7 @@
 use register::{cpu::RegisterReadWrite, register_bitfields};
 
 register_bitfields! {u64,
-    SPSR_EL3 [
+    pub SPSR_EL3 [
         /// Negative condition flag.
         ///
         /// Set to the value of the N condition flag on taking an exception to EL3, and copied to


### PR DESCRIPTION
This allows you to do S{PSR,CR}_EL3.write(FieldValues) instead of a raw .set() which I have to do for now.