### PR TITLE
Use full path to asm! macro

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -15,7 +15,7 @@ pub mod barrier;
 pub fn nop() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        asm!("nop", options(nomem, nostack))
+        core::arch::asm!("nop", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -29,7 +29,7 @@ pub fn nop() {
 pub fn wfi() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        asm!("wfi", options(nomem, nostack))
+        core::arch::asm!("wfi", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -43,7 +43,7 @@ pub fn wfi() {
 pub fn wfe() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        asm!("wfe", options(nomem, nostack))
+        core::arch::asm!("wfe", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -59,7 +59,7 @@ pub fn wfe() {
 pub fn sevl() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        asm!("sevl", options(nomem, nostack))
+        core::arch::asm!("sevl", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -75,7 +75,7 @@ pub fn sevl() {
 pub fn sev() {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        asm!("sev", options(nomem, nostack))
+        core::arch::asm!("sev", options(nomem, nostack))
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -89,7 +89,7 @@ pub fn sev() {
 pub fn eret() -> ! {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        asm!("eret", options(nomem, nostack));
+        core::arch::asm!("eret", options(nomem, nostack));
         core::intrinsics::unreachable()
     }
 
@@ -104,7 +104,7 @@ pub fn eret() -> ! {
 pub fn ret() -> ! {
     #[cfg(target_arch = "aarch64")]
     unsafe {
-        asm!("ret", options(nomem, nostack));
+        core::arch::asm!("ret", options(nomem, nostack));
         core::intrinsics::unreachable()
     }
 

--- a/src/asm/barrier.rs
+++ b/src/asm/barrier.rs
@@ -29,7 +29,7 @@ macro_rules! dmb_dsb {
                 match () {
                     #[cfg(target_arch = "aarch64")]
                     () => {
-                        asm!(concat!("DMB ", stringify!($A)), options(nostack))
+                        core::arch::asm!(concat!("DMB ", stringify!($A)), options(nostack))
                     }
 
                     #[cfg(not(target_arch = "aarch64"))]
@@ -43,7 +43,7 @@ macro_rules! dmb_dsb {
                 match () {
                     #[cfg(target_arch = "aarch64")]
                     () => {
-                        asm!(concat!("DSB ", stringify!($A)), options(nostack))
+                        core::arch::asm!(concat!("DSB ", stringify!($A)), options(nostack))
                     }
 
                     #[cfg(not(target_arch = "aarch64"))]
@@ -68,7 +68,7 @@ impl sealed::Isb for SY {
         match () {
             #[cfg(target_arch = "aarch64")]
             () => {
-                asm!("ISB SY", options(nostack))
+                core::arch::asm!("ISB SY", options(nostack))
             }
 
             #[cfg(not(target_arch = "aarch64"))]

--- a/src/registers/macros.rs
+++ b/src/registers/macros.rs
@@ -15,7 +15,7 @@ macro_rules! __read_raw {
                 () => {
                     let reg;
                     unsafe {
-                        asm!(concat!($asm_instr, " {reg:", $asm_width, "}, ", $asm_reg_name), reg = out(reg) reg, options(nomem, nostack));
+                        core::arch::asm!(concat!($asm_instr, " {reg:", $asm_width, "}, ", $asm_reg_name), reg = out(reg) reg, options(nomem, nostack));
                     }
                     reg
                 }
@@ -37,7 +37,7 @@ macro_rules! __write_raw {
                 #[cfg(target_arch = "aarch64")]
                 () => {
                     unsafe {
-                        asm!(concat!($asm_instr, " ", $asm_reg_name, ", {reg:", $asm_width, "}"), reg = in(reg) value, options(nomem, nostack))
+                        core::arch::asm!(concat!($asm_instr, " ", $asm_reg_name, ", {reg:", $asm_width, "}"), reg = in(reg) value, options(nomem, nostack))
                     }
                 }
 


### PR DESCRIPTION
Rust 1.59 stabilizes the asm feature and the explicit feature flag is
not required anymore. However, the macros were not using the full path
and this is causing a failure with rustc 1.59 in nightly.

```
error: cannot find macro `asm` in this scope
  --> src/registers/macros.rs:40:25
   |
40 | ...   asm!(concat!($asm_instr, " ", $asm_reg_name, ", {reg:", $asm_width, "}"), reg = in(reg) value, options(nomem, nostack))
   |       ^^^
   |
  ::: src/registers/cnthctl_el2.rs:70:5
   |
70 |     sys_coproc_write_raw!(u64, "CNTHCTL_EL2", "x");
   |     ---------------------------------------------- in this macro invocation
   |
   = note: consider importing this macro:
           core::arch::asm
   = note: this error originates in the macro `__write_raw` (in Nightly builds, run with -Z macro-backtrace for more info)
```