### PR TITLE
Add functions for HVC and SMC calls.

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -111,3 +111,151 @@ pub fn ret() -> ! {
     #[cfg(not(target_arch = "aarch64"))]
     unimplemented!()
 }
+
+/// Make an HVC32 call to the hypervisor, following the SMC Calling Convention version 1.3.
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+pub fn hvc32(
+    function: u32,
+    arg1: u32,
+    arg2: u32,
+    arg3: u32,
+    arg4: u32,
+    arg5: u32,
+    arg6: u32,
+    arg7: u32,
+) -> [u32; 8] {
+    let mut ret = [0; 8];
+
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        core::arch::asm!(
+            "hvc #0",
+            inout("w0") function => ret[0],
+            inout("w1") arg1 => ret[1],
+            inout("w2") arg2 => ret[2],
+            inout("w3") arg3 => ret[3],
+            inout("w4") arg4 => ret[4],
+            inout("w5") arg5 => ret[5],
+            inout("w6") arg6 => ret[6],
+            inout("w7") arg7 => ret[7],
+            options(nomem, nostack)
+        )
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    unimplemented!();
+
+    ret
+}
+
+/// Make an HVC64 call to the hypervisor, following the SMC Calling Convention version 1.3.
+#[inline(always)]
+pub fn hvc64(function: u32, args: [u64; 17]) -> [u64; 18] {
+    let mut ret = [0; 18];
+
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        core::arch::asm!(
+            "hvc #0",
+            inout("x0") function as u64 => ret[0],
+            inout("x1") args[0] => ret[1],
+            inout("x2") args[1] => ret[2],
+            inout("x3") args[2] => ret[3],
+            inout("x4") args[3] => ret[4],
+            inout("x5") args[4] => ret[5],
+            inout("x6") args[5] => ret[6],
+            inout("x7") args[6] => ret[7],
+            inout("x8") args[7] => ret[8],
+            inout("x9") args[8] => ret[9],
+            inout("x10") args[9] => ret[10],
+            inout("x11") args[10] => ret[11],
+            inout("x12") args[11] => ret[12],
+            inout("x13") args[12] => ret[13],
+            inout("x14") args[13] => ret[14],
+            inout("x15") args[14] => ret[15],
+            inout("x16") args[15] => ret[16],
+            inout("x17") args[16] => ret[17],
+            options(nomem, nostack)
+        )
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    unimplemented!();
+
+    ret
+}
+
+/// Make an SMC32 call to the firmware, following the SMC Calling Convention version 1.3.
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+pub fn smc32(
+    function: u32,
+    arg1: u32,
+    arg2: u32,
+    arg3: u32,
+    arg4: u32,
+    arg5: u32,
+    arg6: u32,
+    arg7: u32,
+) -> [u32; 8] {
+    let mut ret = [0; 8];
+
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        core::arch::asm!(
+            "smc #0",
+            inout("w0") function => ret[0],
+            inout("w1") arg1 => ret[1],
+            inout("w2") arg2 => ret[2],
+            inout("w3") arg3 => ret[3],
+            inout("w4") arg4 => ret[4],
+            inout("w5") arg5 => ret[5],
+            inout("w6") arg6 => ret[6],
+            inout("w7") arg7 => ret[7],
+            options(nomem, nostack)
+        )
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    unimplemented!();
+
+    ret
+}
+
+/// Make an SMC64 call to the firmware, following the SMC Calling Convention version 1.3.
+#[inline(always)]
+pub fn smc64(function: u32, args: [u64; 17]) -> [u64; 18] {
+    let mut ret = [0; 18];
+
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        core::arch::asm!(
+            "smc #0",
+            inout("x0") function as u64 => ret[0],
+            inout("x1") args[0] => ret[1],
+            inout("x2") args[1] => ret[2],
+            inout("x3") args[2] => ret[3],
+            inout("x4") args[3] => ret[4],
+            inout("x5") args[4] => ret[5],
+            inout("x6") args[5] => ret[6],
+            inout("x7") args[6] => ret[7],
+            inout("x8") args[7] => ret[8],
+            inout("x9") args[8] => ret[9],
+            inout("x10") args[9] => ret[10],
+            inout("x11") args[10] => ret[11],
+            inout("x12") args[11] => ret[12],
+            inout("x13") args[12] => ret[13],
+            inout("x14") args[13] => ret[14],
+            inout("x15") args[14] => ret[15],
+            inout("x16") args[15] => ret[16],
+            inout("x17") args[16] => ret[17],
+            options(nomem, nostack)
+        )
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    unimplemented!();
+
+    ret
+}

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -114,17 +114,7 @@ pub fn ret() -> ! {
 
 /// Make an HVC32 call to the hypervisor, following the SMC Calling Convention version 1.3.
 #[inline(always)]
-#[allow(clippy::too_many_arguments)]
-pub fn hvc32(
-    function: u32,
-    arg1: u32,
-    arg2: u32,
-    arg3: u32,
-    arg4: u32,
-    arg5: u32,
-    arg6: u32,
-    arg7: u32,
-) -> [u32; 8] {
+pub fn hvc32(function: u32, args: [u32; 7]) -> [u32; 8] {
     let mut ret = [0; 8];
 
     #[cfg(target_arch = "aarch64")]
@@ -132,13 +122,13 @@ pub fn hvc32(
         core::arch::asm!(
             "hvc #0",
             inout("w0") function => ret[0],
-            inout("w1") arg1 => ret[1],
-            inout("w2") arg2 => ret[2],
-            inout("w3") arg3 => ret[3],
-            inout("w4") arg4 => ret[4],
-            inout("w5") arg5 => ret[5],
-            inout("w6") arg6 => ret[6],
-            inout("w7") arg7 => ret[7],
+            inout("w1") args[0] => ret[1],
+            inout("w2") args[1] => ret[2],
+            inout("w3") args[2] => ret[3],
+            inout("w4") args[3] => ret[4],
+            inout("w5") args[4] => ret[5],
+            inout("w6") args[5] => ret[6],
+            inout("w7") args[6] => ret[7],
             options(nomem, nostack)
         )
     }
@@ -188,17 +178,7 @@ pub fn hvc64(function: u32, args: [u64; 17]) -> [u64; 18] {
 
 /// Make an SMC32 call to the firmware, following the SMC Calling Convention version 1.3.
 #[inline(always)]
-#[allow(clippy::too_many_arguments)]
-pub fn smc32(
-    function: u32,
-    arg1: u32,
-    arg2: u32,
-    arg3: u32,
-    arg4: u32,
-    arg5: u32,
-    arg6: u32,
-    arg7: u32,
-) -> [u32; 8] {
+pub fn smc32(function: u32, args: [u32; 7]) -> [u32; 8] {
     let mut ret = [0; 8];
 
     #[cfg(target_arch = "aarch64")]
@@ -206,13 +186,13 @@ pub fn smc32(
         core::arch::asm!(
             "smc #0",
             inout("w0") function => ret[0],
-            inout("w1") arg1 => ret[1],
-            inout("w2") arg2 => ret[2],
-            inout("w3") arg3 => ret[3],
-            inout("w4") arg4 => ret[4],
-            inout("w5") arg5 => ret[5],
-            inout("w6") arg6 => ret[6],
-            inout("w7") arg7 => ret[7],
+            inout("w1") args[0] => ret[1],
+            inout("w2") args[1] => ret[2],
+            inout("w3") args[2] => ret[3],
+            inout("w4") args[3] => ret[4],
+            inout("w5") args[4] => ret[5],
+            inout("w6") args[5] => ret[6],
+            inout("w7") args[6] => ret[7],
             options(nomem, nostack)
         )
     }


### PR DESCRIPTION
These follow the [Arm SMC Calling Convention version 1.3](https://documentation-service.arm.com/static/6013e5faeee5236980d08619). I've somewhat arbitrarily used function parameters for the HVC32/SMC32 calls and an array of arguments for the HVC64/SMC64 versions, because they take more arguments.