### PR TITLE
Fix doc tests and `cargo doc` warnings.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,10 @@
 //!
 //! ### Example
 //!
-//! Check out https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials for usage examples.
-//! Listed below is a snippet of `rust-raspberrypi-OS-tutorials`'s early boot code.
+//! Check out
+//! [rust-raspberrypi-OS-tutorials](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials)
+//! for usage examples. Listed below is a snippet of `rust-raspberrypi-OS-tutorials`'s early boot
+//! code.
 //!
 //! ```rust
 //! use cortex_a::{asm, registers::*};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //!             + SPSR_EL2::F::Masked
 //!             + SPSR_EL2::M::EL1h,
 //!     );
+//! }
 //! ```
 //!
 //! ## Disclaimer

--- a/src/registers/hcr_el2.rs
+++ b/src/registers/hcr_el2.rs
@@ -27,11 +27,11 @@ register_bitfields! {u64,
         /// Traps are reported using EC syndrome value 0x09. The Pointer Authentication instructions
         /// trapped are:
         ///
-        ///     AUTDA, AUTDB, AUTDZA, AUTDZB, AUTIA, AUTIA1716, AUTIASP, AUTIAZ, AUTIB, AUTIB1716,
-        ///     AUTIBSP, AUTIBZ, AUTIZA, AUTIZB, PACGA, PACDA, PACDB, PACDZA, PACDZB, PACIA,
-        ///     PACIA1716, PACIASP, PACIAZ, PACIB, PACIB1716, PACIBSP, PACIBZ, PACIZA, PACIZB.
-        ///     RETAA, RETAB, BRAA, BRAB, BLRAA, BLRAB, BRAAZ, BRABZ, BLRAAZ, BLRABZ.
-        ///     ERETAA, ERETAB, LDRAA, and LDRAB.
+        /// `AUTDA`, `AUTDB`, `AUTDZA`, `AUTDZB`, `AUTIA`, `AUTIA1716`, `AUTIASP`, `AUTIAZ`, `AUTIB`, `AUTIB1716`,
+        /// `AUTIBSP`, `AUTIBZ`, `AUTIZA`, `AUTIZB`, `PACGA`, `PACDA`, `PACDB`, `PACDZA`, `PACDZB`, `PACIA`,
+        /// `PACIA1716`, `PACIASP`, `PACIAZ`, `PACIB`, `PACIB1716`, `PACIBSP`, `PACIBZ`, `PACIZA`, `PACIZB`,
+        /// `RETAA`, `RETAB`, `BRAA`, `BRAB`, `BLRAA`, `BLRAB`, `BRAAZ`, `BRABZ`, `BLRAAZ`, `BLRABZ`,
+        /// `ERETAA`, `ERETAB`, `LDRAA`, and `LDRAB`.
         API   OFFSET(41) NUMBITS(1) [
             EnableTrapPointerAuthInstToEl2 = 0,
             DisableTrapPointerAuthInstToEl2 = 1
@@ -41,8 +41,8 @@ register_bitfields! {u64,
         /// following registers from EL1 to EL2, when EL2 is enabled in the current Security state,
         /// reported using EC syndrome value 0x18:
         ///
-        ///     APIAKeyLo_EL1, APIAKeyHi_EL1, APIBKeyLo_EL1, APIBKeyHi_EL1, APDAKeyLo_EL1,
-        ///     APDAKeyHi_EL1, APDBKeyLo_EL1, APDBKeyHi_EL1, APGAKeyLo_EL1, and APGAKeyHi_EL1.
+        /// `APIAKeyLo_EL1`, `APIAKeyHi_EL1`, `APIBKeyLo_EL1`, `APIBKeyHi_EL1`, `APDAKeyLo_EL1`,
+        /// `APDAKeyHi_EL1`, `APDBKeyLo_EL1`, `APDBKeyHi_EL1`, `APGAKeyLo_EL1`, and `APGAKeyHi_EL1`.
         APK   OFFSET(40) NUMBITS(1) [
             EnableTrapPointerAuthKeyRegsToEl2 = 0,
             DisableTrapPointerAuthKeyRegsToEl2 = 1,

--- a/src/registers/oslar_el1.rs
+++ b/src/registers/oslar_el1.rs
@@ -10,8 +10,8 @@
 //!
 //! Used to lock or unlock the OS Lock.
 //!
-//! AArch64 System register OSLAR_EL1 bits [31:0] are architecturally mapped to External register
-//! OSLAR_EL1[31:0]. The OS Lock can also be locked or unlocked using DBGOSLAR.
+//! AArch64 System register `OSLAR_EL1` bits \[31:0\] are architecturally mapped to External
+//! register `OSLAR_EL1[31:0]`. The OS Lock can also be locked or unlocked using `DBGOSLAR`.
 
 use tock_registers::{
     interfaces::{Readable, Writeable},
@@ -20,8 +20,8 @@ use tock_registers::{
 
 register_bitfields! {u64,
     pub OSLAR_EL1 [
-        /// On writes to OSLAR_EL1, bit[0] is copied to the OS Lock.
-        /// Use OSLSR_EL1.OSLK to check the current status of the lock.
+        /// On writes to `OSLAR_EL1`, bit[0] is copied to the OS Lock.
+        /// Use `OSLSR_EL1.OSLK` to check the current status of the lock.
         OSLK OFFSET(0) NUMBITS(1) [
             Unlocked = 0,
             Locked = 1


### PR DESCRIPTION
`cargo test` was failing and `cargo test` was giving some warnings. This fixes both, and tidies up some of the documentation a little.