### PR TITLE
Add `nightly` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,9 @@ exclude = [
         "Makefile"
 ]
 
+[features]
+default = ["nightly"]
+nightly = ["tock-registers"]
+
 [dependencies]
-tock-registers = { version = "0.7.x", default-features = false } # Use it as interface-only library.
+tock-registers = { version = "0.7.x", default-features = false, optional = true } # Use it as interface-only library.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Low level access to Cortex-A processors.
 
 ## Minimum Supported Rust Version
 
-Requires a recent nightly of Rust.
+Requires a recent nightly of Rust if the (default) `nightly` feature is enabled. Without this the
+register access module is not available.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,11 +45,14 @@
 //! Listed below is a snippet of `rust-raspberrypi-OS-tutorials`'s early boot code.
 //!
 //! ```rust
+//! # #[cfg(feature = "nightly")]
 //! use cortex_a::{asm, registers::*};
+//! # #[cfg(feature = "nightly")]
 //! use tock_registers::interfaces::Writeable; // <-- Trait needed to use `write()` and `set()`.
 //!
 //! // Some parts omitted for brevity.
 //!
+//! # #[cfg(feature = "nightly")]
 //! unsafe fn prepare_el2_to_el1_transition(
 //!     virt_boot_core_stack_end_exclusive_addr: u64,
 //!     virt_kernel_init_addr: u64,
@@ -79,9 +82,10 @@
 //! ARMv8, for ARMv8-A architecture
 //! profile](https://static.docs.arm.com/ddi0487/ca/DDI0487C_a_armv8_arm.pdf?_ga=2.266626254.1122218691.1534883460-1326731866.1530967873).
 
-#![feature(core_intrinsics)]
-#![feature(custom_inner_attributes)]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
+#![cfg_attr(feature = "nightly", feature(custom_inner_attributes))]
 #![no_std]
 
 pub mod asm;
+#[cfg(feature = "nightly")]
 pub mod registers;


### PR DESCRIPTION
Without this feature the registers module will be disabled, so the crate can build with stable Rust. It's enabled by default to keep existing behaviour.

Fixes #35.