### PR TITLE
Update tock-registers dependency to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ default = ["nightly"]
 nightly = ["tock-registers"]
 
 [dependencies]
-tock-registers = { version = "0.7.x", default-features = false, optional = true } # Use it as interface-only library.
+tock-registers = { version = "0.8", default-features = false, optional = true } # Use it as interface-only library.


### PR DESCRIPTION
Update for the new version of tock-registers.