### PR TITLE
barrier functions wrap unsafe behaviour

### DIFF
--- a/src/asm/barrier.rs
+++ b/src/asm/barrier.rs
@@ -9,15 +9,15 @@
 
 mod sealed {
     pub trait Dmb {
-        unsafe fn __dmb(&self);
+        fn __dmb(&self);
     }
 
     pub trait Dsb {
-        unsafe fn __dsb(&self);
+        fn __dsb(&self);
     }
 
     pub trait Isb {
-        unsafe fn __isb(&self);
+        fn __isb(&self);
     }
 }
 
@@ -25,11 +25,13 @@ macro_rules! dmb_dsb {
     ($A:ident) => {
         impl sealed::Dmb for $A {
             #[inline(always)]
-            unsafe fn __dmb(&self) {
+            fn __dmb(&self) {
                 match () {
                     #[cfg(target_arch = "aarch64")]
                     () => {
-                        core::arch::asm!(concat!("DMB ", stringify!($A)), options(nostack))
+                        unsafe {
+                            core::arch::asm!(concat!("DMB ", stringify!($A)), options(nostack))
+                        }
                     }
 
                     #[cfg(not(target_arch = "aarch64"))]
@@ -39,11 +41,13 @@ macro_rules! dmb_dsb {
         }
         impl sealed::Dsb for $A {
             #[inline(always)]
-            unsafe fn __dsb(&self) {
+            fn __dsb(&self) {
                 match () {
                     #[cfg(target_arch = "aarch64")]
                     () => {
-                        core::arch::asm!(concat!("DSB ", stringify!($A)), options(nostack))
+                        unsafe {
+                            core::arch::asm!(concat!("DSB ", stringify!($A)), options(nostack))
+                        }
                     }
 
                     #[cfg(not(target_arch = "aarch64"))]
@@ -64,11 +68,13 @@ dmb_dsb!(SY);
 
 impl sealed::Isb for SY {
     #[inline(always)]
-    unsafe fn __isb(&self) {
+    fn __isb(&self) {
         match () {
             #[cfg(target_arch = "aarch64")]
             () => {
-                core::arch::asm!("ISB SY", options(nostack))
+                unsafe {
+                    core::arch::asm!("ISB SY", options(nostack))
+                }
             }
 
             #[cfg(not(target_arch = "aarch64"))]
@@ -77,33 +83,24 @@ impl sealed::Isb for SY {
     }
 }
 
-/// # Safety
-///
-/// In your own hands, this is hardware land!
 #[inline(always)]
-pub unsafe fn dmb<A>(arg: A)
+pub fn dmb<A>(arg: A)
 where
     A: sealed::Dmb,
 {
     arg.__dmb()
 }
 
-/// # Safety
-///
-/// In your own hands, this is hardware land!
 #[inline(always)]
-pub unsafe fn dsb<A>(arg: A)
+pub fn dsb<A>(arg: A)
 where
     A: sealed::Dsb,
 {
     arg.__dsb()
 }
 
-/// # Safety
-///
-/// In your own hands, this is hardware land!
 #[inline(always)]
-pub unsafe fn isb<A>(arg: A)
+pub fn isb<A>(arg: A)
 where
     A: sealed::Isb,
 {


### PR DESCRIPTION
The safety documentation for the barrier functions just say "In your own hands, this is hardware land!" because the programmer doesn't need to check safety when adding a barrier.  Adding a memory barrier does not break the borrow checker, cause undefined behaviour or alter memory in any way.  Therefore, we can make dsb(), dmb() and isb() safe wrappers around the asm code that write the intended assembly.