### PR TITLE
Remove unsafe from barrier instructions

### DIFF
--- a/src/asm/barrier.rs
+++ b/src/asm/barrier.rs
@@ -9,15 +9,15 @@
 
 mod sealed {
     pub trait Dmb {
-        unsafe fn __dmb(&self);
+        fn __dmb(&self);
     }
 
     pub trait Dsb {
-        unsafe fn __dsb(&self);
+        fn __dsb(&self);
     }
 
     pub trait Isb {
-        unsafe fn __isb(&self);
+        fn __isb(&self);
     }
 }
 
@@ -25,12 +25,12 @@ macro_rules! dmb_dsb {
     ($A:ident) => {
         impl sealed::Dmb for $A {
             #[inline(always)]
-            unsafe fn __dmb(&self) {
+            fn __dmb(&self) {
                 match () {
                     #[cfg(target_arch = "aarch64")]
-                    () => {
+                    () => unsafe {
                         core::arch::asm!(concat!("DMB ", stringify!($A)), options(nostack))
-                    }
+                    },
 
                     #[cfg(not(target_arch = "aarch64"))]
                     () => unimplemented!(),
@@ -39,12 +39,12 @@ macro_rules! dmb_dsb {
         }
         impl sealed::Dsb for $A {
             #[inline(always)]
-            unsafe fn __dsb(&self) {
+            fn __dsb(&self) {
                 match () {
                     #[cfg(target_arch = "aarch64")]
-                    () => {
+                    () => unsafe {
                         core::arch::asm!(concat!("DSB ", stringify!($A)), options(nostack))
-                    }
+                    },
 
                     #[cfg(not(target_arch = "aarch64"))]
                     () => unimplemented!(),
@@ -64,12 +64,10 @@ dmb_dsb!(SY);
 
 impl sealed::Isb for SY {
     #[inline(always)]
-    unsafe fn __isb(&self) {
+    fn __isb(&self) {
         match () {
             #[cfg(target_arch = "aarch64")]
-            () => {
-                core::arch::asm!("ISB SY", options(nostack))
-            }
+            () => unsafe { core::arch::asm!("ISB SY", options(nostack)) },
 
             #[cfg(not(target_arch = "aarch64"))]
             () => unimplemented!(),
@@ -77,33 +75,27 @@ impl sealed::Isb for SY {
     }
 }
 
-/// # Safety
-///
-/// In your own hands, this is hardware land!
+/// Data Memory Barrier.
 #[inline(always)]
-pub unsafe fn dmb<A>(arg: A)
+pub fn dmb<A>(arg: A)
 where
     A: sealed::Dmb,
 {
     arg.__dmb()
 }
 
-/// # Safety
-///
-/// In your own hands, this is hardware land!
+/// Data Synchronization Barrier.
 #[inline(always)]
-pub unsafe fn dsb<A>(arg: A)
+pub fn dsb<A>(arg: A)
 where
     A: sealed::Dsb,
 {
     arg.__dsb()
 }
 
-/// # Safety
-///
-/// In your own hands, this is hardware land!
+/// Instruction Synchronization Barrier.
 #[inline(always)]
-pub unsafe fn isb<A>(arg: A)
+pub fn isb<A>(arg: A)
 where
     A: sealed::Isb,
 {


### PR DESCRIPTION
Usage of barriers does not compromise memory safety. They shouldn't have been unsafe to begin with.