### PR TITLE
Add all memory barrier variants

### DIFF
--- a/src/asm/barrier.rs
+++ b/src/asm/barrier.rs
@@ -55,12 +55,30 @@ macro_rules! dmb_dsb {
 }
 
 pub struct SY;
+pub struct ST;
+pub struct LD;
 pub struct ISH;
 pub struct ISHST;
+pub struct ISHLD;
+pub struct NSH;
+pub struct NSHST;
+pub struct NSHLD;
+pub struct OSH;
+pub struct OSHST;
+pub struct OSHLD;
 
+dmb_dsb!(SY);
+dmb_dsb!(ST);
+dmb_dsb!(LD);
 dmb_dsb!(ISH);
 dmb_dsb!(ISHST);
-dmb_dsb!(SY);
+dmb_dsb!(ISHLD);
+dmb_dsb!(NSH);
+dmb_dsb!(NSHST);
+dmb_dsb!(NSHLD);
+dmb_dsb!(OSH);
+dmb_dsb!(OSHST);
+dmb_dsb!(OSHLD);
 
 impl sealed::Isb for SY {
     #[inline(always)]


### PR DESCRIPTION
The [Arm A-profile A64 Instruction Set Architecture](https://developer.arm.com/documentation/ddi0602/) specifies many memory barrier variants.  In the 2022-09 version of the document, they are in pages 348 and 351 for the DMB and DSB respectively.

The cortex-a crate only supports SY, ISH and ISHST currently.  Add the rest.